### PR TITLE
Added build dependency File::chmod

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,8 @@ build_command = make lib
 install_command = %x -I../../inc -MAlien::LIBSVM::ModuleBuild -e install_helper %s
 
 [AutoPrereqs]
+[Prereqs / BuildRequires]
+File::chmod = 0
 [PkgVersion]
 [CheckChangeLog]
 [GithubMeta]


### PR DESCRIPTION
File::chmod is used in inc/Alien/LIBSVM/ModuleBuild.pm and Dist::Zilla [AutoPrereqs] don't look in inc.