### PR TITLE
Document and test paths to executables

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -10,6 +10,20 @@ Alien::LIBSVM - Alien package for the LIBSVM library
 
 version 0.003
 
+=head1 METHODS
+
+=head2 svm_train_path
+
+Path to the C<svm-train> executable.
+
+=head2 svm_predict_path
+
+Path to the C<svm-predict> executable.
+
+=head2 svm_scale_path
+
+Path to the C<svm-scale> executable.
+
 =head1 Inline support
 
 This module supports L<Inline's with functionality|Inline/"Playing 'with' Others">.

--- a/lib/Alien/LIBSVM.pm
+++ b/lib/Alien/LIBSVM.pm
@@ -36,16 +36,31 @@ sub Inline {
 	my $params = Alien::Base::Inline(@_);
 }
 
+=method svm_train_path
+
+Path to the C<svm-train> executable.
+
+=cut
 sub svm_train_path {
 	my ($self) = @_;
 	File::Spec->catfile( $self->dist_dir , 'bin', 'svm-train' );
 }
 
+=method svm_predict_path
+
+Path to the C<svm-predict> executable.
+
+=cut
 sub svm_predict_path {
 	my ($self) = @_;
 	File::Spec->catfile( $self->dist_dir , 'bin', 'svm-predict' );
 }
 
+=method svm_scale_path
+
+Path to the C<svm-scale> executable.
+
+=cut
 sub svm_scale_path {
 	my ($self) = @_;
 	File::Spec->catfile( $self->dist_dir , 'bin', 'svm-scale' );

--- a/t/run.t
+++ b/t/run.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use Test::Most tests => 1;
+use Path::Tiny;
+
+use Alien::LIBSVM;
+
+# From <https://github.com/cjlin1/libsvm/blob/master/heart_scale>
+my $heart_scale_data_head5 = <<EOF;
++1 1:0.708333 2:1 3:1 4:-0.320755 5:-0.105023 6:-1 7:1 8:-0.419847 9:-1 10:-0.225806 12:1 13:-1
+-1 1:0.583333 2:-1 3:0.333333 4:-0.603774 5:1 6:-1 7:1 8:0.358779 9:-1 10:-0.483871 12:-1 13:1
++1 1:0.166667 2:1 3:-0.333333 4:-0.433962 5:-0.383562 6:-1 7:-1 8:0.0687023 9:-1 10:-0.903226 11:-1 12:-1 13:1
+-1 1:0.458333 2:1 3:1 4:-0.358491 5:-0.374429 6:-1 7:-1 8:-0.480916 9:1 10:-0.935484 12:-0.333333 13:1
+-1 1:0.875 2:-1 3:-0.333333 4:-0.509434 5:-0.347032 6:-1 7:1 8:-0.236641 9:1 10:-0.935484 11:-1 12:-0.333333 13:-1
+EOF
+
+subtest "Run svm-train" => sub {
+	my $temp = Path::Tiny->tempfile;
+	$temp->spew_utf8( $heart_scale_data_head5 );
+
+	is system( Alien::LIBSVM->svm_train_path, $temp ), 0, 'svm-train runs';
+};
+
+done_testing;


### PR DESCRIPTION
- Add docs for the `svm_*_path` methods
- Test svm-train executable
